### PR TITLE
hotfix: add use_ema condition for extracting ema_vae in train_step

### DIFF
--- a/muse_maskgit_pytorch/trainers.py
+++ b/muse_maskgit_pytorch/trainers.py
@@ -275,7 +275,8 @@ class VQGanVAETrainer(nn.Module):
 
         self.vae.train()
         discr = self.vae.module.discr if self.is_distributed else self.vae.discr
-        ema_vae = self.ema_vae.module if self.is_distributed else self.ema_vae
+        if self.use_ema:
+            ema_vae = self.ema_vae.module if self.is_distributed else self.ema_vae
 
         # logs
 


### PR DESCRIPTION
There was a mistake in previous PR.
I added if condition when calling 
```
ema_vae = self.ema_vae.module if self.is_distributed else self.ema_vae
```

so it is to be:
```
if self.use_ema:
    ema_vae = self.ema_vae.module if self.is_distributed else self.ema_vae
```
in train_step.