### PR TITLE
Missing pathlib import

### DIFF
--- a/muse_maskgit_pytorch/muse_maskgit_pytorch.py
+++ b/muse_maskgit_pytorch/muse_maskgit_pytorch.py
@@ -5,7 +5,8 @@ from functools import partial
 import torch
 import torch.nn.functional as F
 from torch import nn, einsum
-
+import Pathlib
+from Pathlib import Path
 import torchvision.transforms as T
 
 from typing import Callable, Optional, List

--- a/muse_maskgit_pytorch/muse_maskgit_pytorch.py
+++ b/muse_maskgit_pytorch/muse_maskgit_pytorch.py
@@ -5,8 +5,8 @@ from functools import partial
 import torch
 import torch.nn.functional as F
 from torch import nn, einsum
-import Pathlib
-from Pathlib import Path
+import pathlib
+from pathlib import Path
 import torchvision.transforms as T
 
 from typing import Callable, Optional, List


### PR DESCRIPTION
Path() is called on line 480 of muse_maskgit_pytorch.py, but pathlib isn't imported in the file.