### PR TITLE
self.training removed

### DIFF
--- a/muse_maskgit_pytorch/muse_maskgit_pytorch.py
+++ b/muse_maskgit_pytorch/muse_maskgit_pytorch.py
@@ -305,7 +305,7 @@ class Transformer(nn.Module):
 
         # classifier free guidance
 
-        if self.training and cond_drop_prob > 0.:
+        if cond_drop_prob > 0.:
             mask = prob_mask_like((b, 1), 1. - cond_drop_prob, device)
             context_mask = context_mask & mask
 


### PR DESCRIPTION
I guess the self.training  in the forward is not allowing to create the zeros mask for the null logits during inference. 